### PR TITLE
New updates to logic, DB restore on reload, and updated options

### DIFF
--- a/custom_components/ldata/__init__.py
+++ b/custom_components/ldata/__init__.py
@@ -15,9 +15,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     
+    # --- START OF CHANGE ---
+    # Handle backward compatibility for username/email field
+    # Try to get the new 'email' key, but fall back to the old 'username' key if it doesn't exist.
+    username = entry.data.get("email", entry.data.get("username"))
+    # --- END OF CHANGE ---
+
     coordinator = LDATAUpdateCoordinator(
         hass,
-        entry.data["email"],
+        username, # Use the resolved username
         entry.data["password"],
         30, # Update interval in seconds
         entry,

--- a/custom_components/ldata/__init__.py
+++ b/custom_components/ldata/__init__.py
@@ -1,14 +1,17 @@
 """The LDATA integration."""
 from __future__ import annotations
+import logging
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER_NAME, UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT
 from .coordinator import LDATAUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+_LOGGER = logging.getLogger(LOGGER_NAME)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up LDATA from a config entry."""
@@ -18,36 +21,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Handle backward compatibility for username/email field
     username = entry.data.get("email", entry.data.get("username"))
 
+    # Get the update interval from options and enforce a 30-second minimum.
+    user_update_interval = entry.options.get(UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT)
+    update_interval = max(user_update_interval, 30)
+
+    if user_update_interval < 30:
+        _LOGGER.warning(
+            "Update interval was set to %s seconds, which is too frequent. "
+            "Forcing a minimum interval of 30 seconds to avoid API rate limiting.",
+            user_update_interval,
+        )
+
     coordinator = LDATAUpdateCoordinator(
         hass,
         username,
         entry.data["password"],
-        30, # Update interval in seconds
+        update_interval, # Use the validated update_interval
         entry,
     )
 
-    # --- START OF CHANGE ---
-    # Only perform the first refresh during initial setup.
     if entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
         await coordinator.async_config_entry_first_refresh()
-    # --- END OF CHANGE ---
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    #entry.add_update_listener(async_reload_entry)
+    # Set up a listener for options updates
+    entry.add_update_listener(options_update_listener)
 
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+    # Use the built-in unload method
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    return unload_ok
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+async def options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    # This is the recommended way to handle options updates.
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/ldata/__init__.py
+++ b/custom_components/ldata/__init__.py
@@ -1,86 +1,47 @@
-"""The Leviton LDATA integration."""
-
+"""The LDATA integration."""
 from __future__ import annotations
 
-import asyncio
-import logging
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    DOMAIN,
-    LOGGER_NAME,
-    READ_ONLY,
-    READ_ONLY_DEFAULT,
-    THREE_PHASE,
-    THREE_PHASE_DEFAULT,
-    UPDATE_INTERVAL,
-    UPDATE_INTERVAL_DEFAULT,
-    UPDATE_INTERVAL_MIN,
-)
+from .const import DOMAIN
 from .coordinator import LDATAUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
-
-_LOGGER = logging.getLogger(LOGGER_NAME)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the LDATA component."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Leviton LDATA from a config entry."""
+    """Set up LDATA from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
-    user = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
-    update_interval = entry.options.get(UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT)
-    three_phase = entry.options.get(
-        THREE_PHASE, entry.data.get(THREE_PHASE, THREE_PHASE_DEFAULT)
+    
+    coordinator = LDATAUpdateCoordinator(
+        hass,
+        entry.data["email"],
+        entry.data["password"],
+        30, # Update interval in seconds
+        entry,
     )
-    read_only = entry.options.get(
-        READ_ONLY, entry.data.get(READ_ONLY, READ_ONLY_DEFAULT)
-    )
 
-    # Don't update more that every 10 seconds.
-    update_interval = max(update_interval, UPDATE_INTERVAL_MIN)
-
-    _LOGGER.debug("LDATA update interval: %d", update_interval)
-    _LOGGER.debug("LDATA three phase: %d", three_phase)
-    _LOGGER.debug("LDATA read only: %d", read_only)
-
-    coordinator = LDATAUpdateCoordinator(hass, user, password, update_interval, entry)
-
-    await coordinator.async_refresh()  # Get initial data
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    return True
+    # Add a listener to reload the integration when options are changed
+    entry.add_update_listener(async_reload_entry)
 
+    return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
-    if unload_ok:
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload config entry."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)

--- a/custom_components/ldata/config_flow.py
+++ b/custom_components/ldata/config_flow.py
@@ -97,13 +97,11 @@ class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
 
-
     async def async_step_init(self, user_input=None) -> ConfigFlowResult:
         """Return the options form."""
-        log_fields_note = "To find field names, enable 'Log All Raw' and check Home Assistant logs. Enter values as comma separated and submit."
-
         if user_input is not None:
-            if user_input.get("log_fields") == log_fields_note:
+            # If 'log_fields' is empty or just whitespace, ensure it's saved as an empty string.
+            if "log_fields" in user_input and not user_input["log_fields"].strip():
                 user_input["log_fields"] = ""
             return self.async_create_entry(title="", data=user_input)
         
@@ -132,9 +130,12 @@ class OptionsFlow(config_entries.OptionsFlow):
                 default=current_options.get("log_all_raw", False),
             ): bool,
             vol.Optional(
+                "enable_specific_logging",
+                default=current_options.get("enable_specific_logging", False),
+            ): bool,
+            vol.Optional(
                 "log_fields",
                 default=current_options.get("log_fields", ""),
-                description={"suggested_value": log_fields_note},
             ): selector.TextSelector(selector.TextSelectorConfig(multiline=True)),
         }
 

--- a/custom_components/ldata/config_flow.py
+++ b/custom_components/ldata/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for LDATA."""
+"""Config flow for Leviton LDATA integration."""
 from __future__ import annotations
 
 import logging
@@ -6,79 +6,144 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigEntry, OptionsFlow
-from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import selector
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    LOGGER_NAME,
+    READ_ONLY,
+    READ_ONLY_DEFAULT,
+    THREE_PHASE,
+    THREE_PHASE_DEFAULT,
+    UPDATE_INTERVAL,
+    UPDATE_INTERVAL_DEFAULT,
+)
 from .ldata_service import LDATAService
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(LOGGER_NAME)
 
-class LDATAConfigFlow(ConfigFlow, domain=DOMAIN):
-    """LDATA config flow."""
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("username"): str,
+        vol.Required("password"): str,
+        vol.Required("three_phase"): bool,
+        vol.Required("read_only"): bool,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    service = LDATAService(data[CONF_USERNAME], data[CONF_PASSWORD], data[THREE_PHASE])
+    try:
+        result = await hass.async_add_executor_job(service.auth)
+    except Exception as ex:
+        raise InvalidAuth from ex
+
+    if not result:
+        _LOGGER.error("Failed to authenticate with Leviton API")
+        raise CannotConnect
+    
+    return {"title": f"Leviton LDATA ({data[CONF_USERNAME]})"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Leviton LDATA."""
 
     VERSION = 1
+    DOMAIN = DOMAIN
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle a flow initialized by the user."""
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            service = LDATAService(user_input["email"], user_input["password"], None)
-            if await self.hass.async_add_executor_job(service.login):
-                await self.async_set_unique_id(user_input["email"])
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=user_input["email"], data=user_input
-                )
-            errors["base"] = "auth"
-        
+                return self.async_create_entry(title=info["title"], data=user_input)
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("email"): str,
-                    vol.Required("password"): str,
-                }
-            ),
+            data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )
-    
+
     @staticmethod
     @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> OptionsFlow:
-        """Create the options flow."""
-        return OptionsFlowHandler(config_entry)
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> "OptionsFlow":
+        """Get the options flow for this handler."""
+        return OptionsFlow(config_entry)
 
 
-class OptionsFlowHandler(OptionsFlow):
-    def __init__(self, config_entry: ConfigEntry) -> None:
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle the options flow for Leviton LDATA."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Manage the options."""
+
+    async def async_step_init(self, user_input=None) -> ConfigFlowResult:
+        """Return the options form."""
+        log_fields_note = "To find field names, enable 'Log All Raw' and check Home Assistant logs. Enter values as comma separated and submit."
+
         if user_input is not None:
+            if user_input.get("log_fields") == log_fields_note:
+                user_input["log_fields"] = ""
             return self.async_create_entry(title="", data=user_input)
+        
+        current_options = self.config_entry.options
+        current_data = self.config_entry.data
 
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        "log_warnings",
-                        default=self.config_entry.options.get("log_warnings", True),
-                    ): bool,
-                    vol.Optional(
-                        "log_raw_data",
-                        default=self.config_entry.options.get("log_raw_data", False),
-                    ): bool,
-                }
-            ),
-        )
+        options_schema = {
+            vol.Optional(
+                UPDATE_INTERVAL,
+                default=current_options.get(UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT),
+            ): int,
+            vol.Optional(
+                THREE_PHASE,
+                default=current_options.get(THREE_PHASE, current_data.get(THREE_PHASE, THREE_PHASE_DEFAULT)),
+            ): bool,
+            vol.Optional(
+                READ_ONLY,
+                default=current_options.get(READ_ONLY, current_data.get(READ_ONLY, READ_ONLY_DEFAULT)),
+            ): bool,
+            vol.Optional(
+                "log_warnings",
+                default=current_options.get("log_warnings", True),
+            ): bool,
+            vol.Optional(
+                "log_all_raw",
+                default=current_options.get("log_all_raw", False),
+            ): bool,
+            vol.Optional(
+                "log_fields",
+                default=current_options.get("log_fields", ""),
+                description={"suggested_value": log_fields_note},
+            ): selector.TextSelector(selector.TextSelectorConfig(multiline=True)),
+        }
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options_schema))
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/custom_components/ldata/config_flow.py
+++ b/custom_components/ldata/config_flow.py
@@ -100,7 +100,6 @@ class OptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None) -> ConfigFlowResult:
         """Return the options form."""
         if user_input is not None:
-            # If 'log_fields' is empty or just whitespace, ensure it's saved as an empty string.
             if "log_fields" in user_input and not user_input["log_fields"].strip():
                 user_input["log_fields"] = ""
             return self.async_create_entry(title="", data=user_input)
@@ -112,7 +111,7 @@ class OptionsFlow(config_entries.OptionsFlow):
             vol.Optional(
                 UPDATE_INTERVAL,
                 default=current_options.get(UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT),
-            ): int,
+            ): vol.All(vol.Coerce(int), vol.Range(min=30)),
             vol.Optional(
                 THREE_PHASE,
                 default=current_options.get(THREE_PHASE, current_data.get(THREE_PHASE, THREE_PHASE_DEFAULT)),

--- a/custom_components/ldata/config_flow.py
+++ b/custom_components/ldata/config_flow.py
@@ -125,6 +125,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                 default=current_options.get("log_warnings", True),
             ): bool,
             vol.Optional(
+                "log_data_warnings",
+                default=current_options.get("log_data_warnings", True),
+            ): bool,
+            vol.Optional(
                 "log_all_raw",
                 default=current_options.get("log_all_raw", False),
             ): bool,

--- a/custom_components/ldata/coordinator.py
+++ b/custom_components/ldata/coordinator.py
@@ -24,13 +24,15 @@ class LDATAUpdateCoordinator(DataUpdateCoordinator):
         self.user = user
         self._service = LDATAService(user, password, entry)
         self._available = True
-        self.config_entry = entry  # Add this line to store the config entry
+        self.config_entry = entry
 
+        # The config_entry parameter is now passed to the parent class
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=update_interval),
+            config_entry=entry,
         )
 
     async def _async_update_data(self):
@@ -41,9 +43,25 @@ class LDATAUpdateCoordinator(DataUpdateCoordinator):
                 returnData = await self._hass.async_add_executor_job(
                     self._service.status  # Fetch new status
                 )
-                # Check the "log_raw_data" option before logging
-                if self.config_entry.options.get("log_raw_data", False):
-                    _LOGGER.warning("Leviton API Data: %s", returnData)
+
+                options = self.config_entry.options
+                
+                if options.get("log_all_raw", False):
+                    _LOGGER.warning("Leviton API Full Data: %s", returnData)
+                
+                elif fields_to_log_str := options.get("log_fields", ""):
+                    fields_to_log = [f.strip() for f in fields_to_log_str.split(',') if f.strip()]
+                    log_output = {}
+
+                    for ct_id, ct_data in returnData.get('cts', {}).items():
+                        for field in fields_to_log:
+                            if field in ct_data:
+                                key_name = f"CT_{ct_id}_{field}"
+                                log_output[key_name] = ct_data[field]
+                    
+                    if log_output:
+                        _LOGGER.warning("Leviton Selected Raw Data: %s", log_output)
+
         except Exception as ex:
             self._available = False  # Mark as unavailable
             _LOGGER.warning(

--- a/custom_components/ldata/coordinator.py
+++ b/custom_components/ldata/coordinator.py
@@ -24,6 +24,7 @@ class LDATAUpdateCoordinator(DataUpdateCoordinator):
         self.user = user
         self._service = LDATAService(user, password, entry)
         self._available = True
+        self.config_entry = entry  # Add this line to store the config entry
 
         super().__init__(
             hass,
@@ -40,6 +41,9 @@ class LDATAUpdateCoordinator(DataUpdateCoordinator):
                 returnData = await self._hass.async_add_executor_job(
                     self._service.status  # Fetch new status
                 )
+                # Check the "log_raw_data" option before logging
+                if self.config_entry.options.get("log_raw_data", False):
+                    _LOGGER.warning("Leviton API Data: %s", returnData)
         except Exception as ex:
             self._available = False  # Mark as unavailable
             _LOGGER.warning(

--- a/custom_components/ldata/sensor.py
+++ b/custom_components/ldata/sensor.py
@@ -721,8 +721,6 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
         self.ct_data = data
         self._pending_state = None
         self._is_spike = False
-        self._pending_reset_value = None
-        self._pending_reset_count = 0 
         try:
             self._state = float(self.ct_data[self.entity_description.key])
         except ValueError:
@@ -748,55 +746,32 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
                 if new_data := cts[self.ct_data["id"]]:
                     new_value = float(new_data[self.entity_description.key])
 
-                    if self._state is not None and new_value < float(self._state):
-                        # --- Handle potential device reset (decreasing value) ---
-                        # Check if the new value is consistent with a reset we're already tracking.
-                        # We use a small tolerance (0.01 kWh) to account for minor fluctuations.
-                        if self._pending_reset_value is not None and abs(new_value - self._pending_reset_value) < 0.01:
-                            self._pending_reset_count += 1
-                            _LOGGER.debug("Consistent reset value for %s seen. Count: %d", self.entity_id, self._pending_reset_count)
-                        else:
-                            # This is a new potential reset. Start tracking it.
+                    # Check for invalid values if a previous state exists
+                    if self._state is not None:
+                        # Ignore if the new value is less than the old one (device reset)
+                        if new_value < float(self._state):
                             _LOGGER.warning(
-                                "Potential device reset for %s. New value %s is lower than %s. Monitoring for consistency.",
-                                self.entity_id, new_value, self._state
-                            )
-                            self._pending_reset_value = new_value
-                            self._pending_reset_count = 1
-                        
-                        # If the count exceeds 10, accept the reset.
-                        if self._pending_reset_count > 10:
-                            _LOGGER.info(
-                                "Device reset for %s confirmed after %d consistent updates. Accepting new value %s.",
-                                self.entity_id, self._pending_reset_count, self._pending_reset_value
-                            )
-                            self._state = self._pending_reset_value
-                            self._pending_reset_value = None
-                            self._pending_reset_count = 0
-                        else:
-                            # Not confirmed yet, so reject this update by exiting.
-                            return
-
-                    else:
-                        # --- Handle normal operation (increasing value) ---
-                        # If we were tracking a reset but received a normal value, clear the tracking.
-                        if self._pending_reset_count > 0:
-                            _LOGGER.info("Device reset for %s was not confirmed. Resuming normal updates.", self.entity_id)
-                            self._pending_reset_value = None
-                            self._pending_reset_count = 0
-
-                        # Ignore unrealistic upward jumps (spike)
-                        if self._state is not None and new_value > (float(self._state) * 1.5) and float(self._state) > 1:
-                            _LOGGER.warning(
-                                "Spike detected for %s: new=%s, old=%s",
-                                self.entity_id, new_value, self._state
+                                "Ignoring decreasing value for %s: new=%s, old=%s",
+                                self.entity_id,
+                                new_value,
+                                self._state,
                             )
                             return # Exit without updating
 
-                        # This is a valid, normal update.
-                        self._state = new_value
+                        # Ignore unrealistic jumps (spike)
+                        if new_value > (float(self._state) * 1.5) and float(self._state) > 1:
+                            _LOGGER.warning(
+                                "Spike detected for %s: new=%s, old=%s",
+                                self.entity_id,
+                                new_value,
+                                self._state,
+                            )
+                            return # Exit without updating
 
+                    # If value is valid, update the state
+                    self._state = new_value
         except (KeyError, ValueError, TypeError):
+            # Handle cases where the value isn't a valid number
             _LOGGER.debug("Invalid value received for %s", self.entity_id)
             return
 

--- a/custom_components/ldata/sensor.py
+++ b/custom_components/ldata/sensor.py
@@ -643,25 +643,29 @@ class LDATACTOutputSensor(LDATACTEntity, SensorEntity):
             if cts := self.coordinator.data["cts"]:
                 if new_data := cts[self.ct_data["id"]]:
                     new_value = float(new_data[self.entity_description.key])
-                    self._is_spike = False # Reset spike flag
+                    is_potential_spike = False # Reset spike flag
 
                     # --- Spike Detection Logic ---
-                    if self._state is not None:
+                    if self._state is None:
+                        # On the first update after a restart, check for an abnormally high initial value.
+                        if abs(new_value) > 3000: # You can adjust this initial threshold
+                            _LOGGER.warning("Potential spike on first update for %s: %s", self.entity_id, new_value)
+                            is_potential_spike = True
+                    else:
+                        # Normal operation: check for spikes relative to the previous state.
                         previous_state = float(self._state)
-                        # Check for a jump from 0 that is unreasonably high
                         if previous_state == 0 and abs(new_value) > 3000:
-                            self._is_spike = True
-                        # Check for a relative jump if not starting from 0
+                            is_potential_spike = True
                         elif previous_state != 0 and abs(new_value) > (abs(previous_state) * 10) and abs(new_value - previous_state) > 2000:
-                            self._is_spike = True
+                            is_potential_spike = True
                     # --- End of Spike Detection ---
 
                     # --- Consistency Check Logic ---
-                    if self._is_spike:
-                        # A spike is detected. Check if it's consistent with a pending value.
+                    if is_potential_spike:
+                        # A potential spike is detected. Check if it's consistent with a pending value.
                         if self._pending_state is not None:
                             # Check if the new value is within 15% of the pending spike value
-                            if abs(new_value - self._pending_state) / self._pending_state < 0.15:
+                            if self._pending_state != 0 and abs(new_value - self._pending_state) / abs(self._pending_state) < 0.15:
                                 # Consistent spike, accept it as the new state
                                 _LOGGER.info("Accepting consistent high value for %s: %s", self.entity_id, new_value)
                                 self._state = new_value
@@ -669,7 +673,7 @@ class LDATACTOutputSensor(LDATACTEntity, SensorEntity):
                             else:
                                 # Not consistent, it was a transient spike. Discard and wait.
                                 _LOGGER.warning("Discarding inconsistent spike for %s: new=%s, pending=%s", self.entity_id, new_value, self._pending_state)
-                                self._pending_state = None # Clear pending state
+                                self._pending_state = new_value # Start a new pending check with the new value
                         else:
                             # This is the first time we see this spike. Store it for verification.
                             _LOGGER.warning("High value detected for %s. Pending verification: %s", self.entity_id, new_value)
@@ -679,7 +683,7 @@ class LDATACTOutputSensor(LDATACTEntity, SensorEntity):
                         self._pending_state = None # Clear any old pending state
                         self._state = new_value
 
-        except (KeyError, ValueError, TypeError):
+        except (KeyError, ValueError, TypeError, ZeroDivisionError):
             self._state = None
             self._pending_state = None
 
@@ -722,7 +726,8 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
         self._pending_state = None
         self._is_spike = False
         self._pending_reset_value = None
-        self._pending_reset_count = 0 
+        self._pending_reset_count = 0
+        self._just_reset = False
         try:
             self._state = float(self.ct_data[self.entity_description.key])
         except ValueError:
@@ -750,13 +755,10 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
 
                     if self._state is not None and new_value < float(self._state):
                         # --- Handle potential device reset (decreasing value) ---
-                        # Check if the new value is consistent with a reset we're already tracking.
-                        # We use a small tolerance (0.01 kWh) to account for minor fluctuations.
                         if self._pending_reset_value is not None and abs(new_value - self._pending_reset_value) < 0.01:
                             self._pending_reset_count += 1
                             _LOGGER.debug("Consistent reset value for %s seen. Count: %d", self.entity_id, self._pending_reset_count)
                         else:
-                            # This is a new potential reset. Start tracking it.
                             _LOGGER.warning(
                                 "Potential device reset for %s. New value %s is lower than %s. Monitoring for consistency.",
                                 self.entity_id, new_value, self._state
@@ -764,7 +766,6 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
                             self._pending_reset_value = new_value
                             self._pending_reset_count = 1
                         
-                        # If the count exceeds 10, accept the reset.
                         if self._pending_reset_count > 10:
                             _LOGGER.info(
                                 "Device reset for %s confirmed after %d consistent updates. Accepting new value %s.",
@@ -773,27 +774,41 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
                             self._state = self._pending_reset_value
                             self._pending_reset_value = None
                             self._pending_reset_count = 0
+                            self._just_reset = True
                         else:
-                            # Not confirmed yet, so reject this update by exiting.
                             return
 
                     else:
                         # --- Handle normal operation (increasing value) ---
-                        # If we were tracking a reset but received a normal value, clear the tracking.
                         if self._pending_reset_count > 0:
                             _LOGGER.info("Device reset for %s was not confirmed. Resuming normal updates.", self.entity_id)
                             self._pending_reset_value = None
                             self._pending_reset_count = 0
 
-                        # Ignore unrealistic upward jumps (spike)
-                        if self._state is not None and new_value > (float(self._state) * 1.5) and float(self._state) > 1:
-                            _LOGGER.warning(
-                                "Spike detected for %s: new=%s, old=%s",
-                                self.entity_id, new_value, self._state
-                            )
-                            return # Exit without updating
+                        if self._just_reset:
+                            _LOGGER.info("Accepting first value %s after a confirmed device reset.", new_value)
+                            self._state = new_value
+                            self._just_reset = False
+                        
+                        # --- CORRECTED SPIKE LOGIC ---
+                        elif self._state is not None:
+                            # Case 1: Check for an absolute spike if starting from a low value
+                            if float(self._state) <= 1 and new_value > 100:
+                                _LOGGER.warning(
+                                    "Spike from zero detected for %s: new=%s, old=%s",
+                                    self.entity_id, new_value, self._state
+                                )
+                                return
+                            # Case 2: Check for a relative spike during normal operation
+                            elif float(self._state) > 1 and new_value > (float(self._state) * 1.5):
+                                _LOGGER.warning(
+                                    "Spike detected for %s: new=%s, old=%s",
+                                    self.entity_id, new_value, self._state
+                                )
+                                return
+                        # --- END CORRECTION ---
 
-                        # This is a valid, normal update.
+                        # If no spike is detected, this is a valid, normal update.
                         self._state = new_value
 
         except (KeyError, ValueError, TypeError):

--- a/custom_components/ldata/sensor.py
+++ b/custom_components/ldata/sensor.py
@@ -331,11 +331,12 @@ class LDATACTDailyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which is added to hass."""
-        self.async_on_remove(self.coordinator.async_add_listener(self._state_update))
         await super().async_added_to_hass()
         if last_state := await self.async_get_last_state():
             try:
                 self._state = float(last_state.state)
+                # Also restore previous_value to handle the first update correctly
+                self.previous_value = float(last_state.state)
             except (ValueError, TypeError):
                 pass # Ignore if the stored state is invalid
 
@@ -364,60 +365,53 @@ class LDATACTDailyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
     def _state_update(self):
         """Call when the coordinator has an update."""
         try:
-            have_values = False
-            new_data = None
-            if self.panel_total is True:
-                current_value = 0
-                current_value = self.coordinator.data[self.panel_id + "totalPower"]
-                have_values = True
-            else:
-                new_data = self.coordinator.data["cts"][self.breaker_data["id"]]
-            if ((self.panel_total is True) and (have_values is True)) or (
-                new_data is not None
-            ):
-                if new_data is not None:
-                    current_value = new_data["consumption"]
-                # Make sure values are floats
-                try:
-                    current_value = float(current_value)
-                except ValueError:
-                    current_value = 0
-                try:
-                    self.previous_value = float(self.previous_value)
-                except ValueError:
-                    self.previous_value = 0
-                # Save the current date and time
-                current_time = time.time()
-                current_date = dt_util.now()
-                # Only update if we have a previous update
-                if self.last_update_time > 0:
-                    # Clear the running total if the last update date and now are not the same day
-                    if (
-                        (self.last_update_date.day != current_date.day)
-                        or (self.last_update_date.month != current_date.month)
-                        or (self.last_update_date.year != current_date.year)
-                    ):
-                        self._state = 0
-                    # Update our running total
-                    try:
-                        value_diff = max(current_value - self.previous_value, 0)
-                        if self._state is not None:
-                            self._state += value_diff
-                        else:
-                            self._state = value_diff
-                    except Exception:  # pylint: disable=broad-except
-                        _LOGGER.exception(
-                            "Error updating sensor! (%f %f)",
-                            self._state,
-                            current_value,
-                        )
-                # Save the current values
-                self.last_update_time = current_time
-                self.previous_value = current_value
-                self.last_update_date = current_date
-        except Exception:  # pylint: disable=broad-except
-            # self._state = None
-            _LOGGER.exception("Error updating sensor!")
+            new_data = self.coordinator.data["cts"][self.breaker_data["id"]]
+            current_value = float(new_data["consumption"])
+            current_date = dt_util.now()
+
+            # Reset the daily total if the day has changed
+            if self._state is not None and self.last_update_date.day != current_date.day:
+                _LOGGER.info("New day detected for %s, resetting daily total.", self.entity_id)
+                self._state = 0.0
+                self.previous_value = 0.0
+
+            # --- Data Validation ---
+            if self.previous_value is not None:
+                # Check for device reset (value decreased)
+                if current_value < self.previous_value:
+                    _LOGGER.warning(
+                        "Ignoring decreasing value for %s: new=%s, old=%s",
+                        self.entity_id,
+                        current_value,
+                        self.previous_value,
+                    )
+                    return # Exit without updating
+
+                # Check for an unrealistic jump (e.g., more than 50 kWh in one update cycle)
+                if (current_value - self.previous_value) > 50:
+                     _LOGGER.warning(
+                        "Spike detected for %s: new=%s, old=%s",
+                        self.entity_id,
+                        current_value,
+                        self.previous_value,
+                    )
+                     return # Exit without updating
+            # --- End Validation ---
+
+            # Calculate the difference and add to the running total
+            value_diff = current_value - self.previous_value
+            if self._state is None:
+                self._state = 0.0
+            self._state += value_diff
+
+            # Save the current values for the next update
+            self.previous_value = current_value
+            self.last_update_date = current_date
+
+        except (KeyError, ValueError, TypeError):
+            _LOGGER.debug("Could not update %s, data missing or invalid.", self.entity_id)
+            return
+
         self.async_write_ha_state()
 
 

--- a/custom_components/ldata/sensor.py
+++ b/custom_components/ldata/sensor.py
@@ -191,7 +191,7 @@ async def async_setup_entry(
         async_add_entities([total_sensor])
 
 
-class LDATADailyUsageSensor(LDATAEntity, RestoreEntity):
+class LDATADailyUsageSensor(LDATAEntity, SensorEntity, RestoreEntity):
     """Sensor that tracks daily usage for an LDATA device."""
 
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -213,6 +213,7 @@ class LDATADailyUsageSensor(LDATAEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which is added to hass."""
+        self.async_on_remove(self.coordinator.async_add_listener(self._state_update))
         await super().async_added_to_hass()
         if last_state := await self.async_get_last_state():
             try:
@@ -308,7 +309,7 @@ class LDATADailyUsageSensor(LDATAEntity, RestoreEntity):
         self.async_write_ha_state()
 
 
-class LDATACTDailyUsageSensor(LDATACTEntity, RestoreEntity):
+class LDATACTDailyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
     """Sensor that tracks daily usage for an LDATA device."""
 
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -330,6 +331,7 @@ class LDATACTDailyUsageSensor(LDATACTEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which is added to hass."""
+        self.async_on_remove(self.coordinator.async_add_listener(self._state_update))
         await super().async_added_to_hass()
         if last_state := await self.async_get_last_state():
             try:
@@ -707,7 +709,7 @@ class LDATACTOutputSensor(LDATACTEntity, SensorEntity):
         return self._state
 
 
-class LDATAEnergyUsageSensor(LDATACTEntity, RestoreEntity):
+class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
     """Sensor that reads an output based on the passed in description from an LDATA CT device."""
 
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -734,6 +736,7 @@ class LDATAEnergyUsageSensor(LDATACTEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which is added to hass."""
+        self.async_on_remove(self.coordinator.async_add_listener(self._state_update))
         await super().async_added_to_hass()
         if last_state := await self.async_get_last_state():
             try:

--- a/custom_components/ldata/sensor.py
+++ b/custom_components/ldata/sensor.py
@@ -721,6 +721,8 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
         self.ct_data = data
         self._pending_state = None
         self._is_spike = False
+        self._pending_reset_value = None
+        self._pending_reset_count = 0 
         try:
             self._state = float(self.ct_data[self.entity_description.key])
         except ValueError:
@@ -746,32 +748,55 @@ class LDATAEnergyUsageSensor(LDATACTEntity, SensorEntity, RestoreEntity):
                 if new_data := cts[self.ct_data["id"]]:
                     new_value = float(new_data[self.entity_description.key])
 
-                    # Check for invalid values if a previous state exists
-                    if self._state is not None:
-                        # Ignore if the new value is less than the old one (device reset)
-                        if new_value < float(self._state):
+                    if self._state is not None and new_value < float(self._state):
+                        # --- Handle potential device reset (decreasing value) ---
+                        # Check if the new value is consistent with a reset we're already tracking.
+                        # We use a small tolerance (0.01 kWh) to account for minor fluctuations.
+                        if self._pending_reset_value is not None and abs(new_value - self._pending_reset_value) < 0.01:
+                            self._pending_reset_count += 1
+                            _LOGGER.debug("Consistent reset value for %s seen. Count: %d", self.entity_id, self._pending_reset_count)
+                        else:
+                            # This is a new potential reset. Start tracking it.
                             _LOGGER.warning(
-                                "Ignoring decreasing value for %s: new=%s, old=%s",
-                                self.entity_id,
-                                new_value,
-                                self._state,
+                                "Potential device reset for %s. New value %s is lower than %s. Monitoring for consistency.",
+                                self.entity_id, new_value, self._state
                             )
-                            return # Exit without updating
+                            self._pending_reset_value = new_value
+                            self._pending_reset_count = 1
+                        
+                        # If the count exceeds 10, accept the reset.
+                        if self._pending_reset_count > 10:
+                            _LOGGER.info(
+                                "Device reset for %s confirmed after %d consistent updates. Accepting new value %s.",
+                                self.entity_id, self._pending_reset_count, self._pending_reset_value
+                            )
+                            self._state = self._pending_reset_value
+                            self._pending_reset_value = None
+                            self._pending_reset_count = 0
+                        else:
+                            # Not confirmed yet, so reject this update by exiting.
+                            return
 
-                        # Ignore unrealistic jumps (spike)
-                        if new_value > (float(self._state) * 1.5) and float(self._state) > 1:
+                    else:
+                        # --- Handle normal operation (increasing value) ---
+                        # If we were tracking a reset but received a normal value, clear the tracking.
+                        if self._pending_reset_count > 0:
+                            _LOGGER.info("Device reset for %s was not confirmed. Resuming normal updates.", self.entity_id)
+                            self._pending_reset_value = None
+                            self._pending_reset_count = 0
+
+                        # Ignore unrealistic upward jumps (spike)
+                        if self._state is not None and new_value > (float(self._state) * 1.5) and float(self._state) > 1:
                             _LOGGER.warning(
                                 "Spike detected for %s: new=%s, old=%s",
-                                self.entity_id,
-                                new_value,
-                                self._state,
+                                self.entity_id, new_value, self._state
                             )
                             return # Exit without updating
 
-                    # If value is valid, update the state
-                    self._state = new_value
+                        # This is a valid, normal update.
+                        self._state = new_value
+
         except (KeyError, ValueError, TypeError):
-            # Handle cases where the value isn't a valid number
             _LOGGER.debug("Invalid value received for %s", self.entity_id)
             return
 

--- a/custom_components/ldata/translations/en.json
+++ b/custom_components/ldata/translations/en.json
@@ -28,7 +28,8 @@
                     "update_interval": "Update Interval (seconds)",
                     "three_phase": "Three Phase System",
                     "read_only": "Read Only Mode",
-                    "log_warnings": "Log Spike & Reset Warnings",
+                    "log_warnings": "Log General Plugin Errors",
+                    "log_data_warnings": "Log Data Value Warnings (Spikes/Resets)",
                     "log_all_raw": "Log All Raw API Data",
                     "enable_specific_logging": "Enable Specific Field Logging",
                     "log_fields": "Fields to Log"

--- a/custom_components/ldata/translations/en.json
+++ b/custom_components/ldata/translations/en.json
@@ -23,12 +23,19 @@
     "options": {
         "step": {
             "init": {
+                "title": "Leviton LDATA Options",
                 "data": {
-                    "update_interval": "Interval to poll my.leviton.com (Seconds)",
-                    "three_phase": "Three phase power",
-                    "read_only": "Read only"
+                    "update_interval": "Update Interval (seconds)",
+                    "three_phase": "Three Phase System",
+                    "read_only": "Read Only Mode",
+                    "log_warnings": "Log Spike & Reset Warnings",
+                    "log_all_raw": "Log All Raw API Data",
+                    "enable_specific_logging": "Enable Specific Field Logging",
+                    "log_fields": "Fields to Log"
                 },
-                "description": "Configure Controller Options"
+                "data_description": {
+                    "log_fields": "To find field names, enable 'Log All Raw API Data' and check Home Assistant logs. Enter here as comma separated."
+                }
             }
         }
     }

--- a/custom_components/ldata/translations/en.json
+++ b/custom_components/ldata/translations/en.json
@@ -34,7 +34,7 @@
                     "log_fields": "Fields to Log"
                 },
                 "data_description": {
-                    "log_fields": "To find field names, enable 'Log All Raw API Data' and check Home Assistant logs. Enter here as comma separated."
+                    "log_fields": "To find field names, enable 'Log All Raw API Data' and check Home Assistant logs. Enter above as comma separated."
                 }
             }
         }

--- a/custom_components/ldata/translations/pt-PT.json
+++ b/custom_components/ldata/translations/pt-PT.json
@@ -34,7 +34,7 @@
                     "log_fields": "Campos a Registar"
                 },
                 "data_description": {
-                    "log_fields": "Para encontrar os nomes dos campos, ative 'Registar Todos os Dados Brutos da API' e verifique os registos do Home Assistant. Insira aqui, separados por vírgulas."
+                    "log_fields": "Para encontrar os nomes dos campos, ative 'Registar Todos os Dados Brutos da API' e verifique os registos do Home Assistant. Digite os dados acima separados por vírgula."
                 }
             }
         }

--- a/custom_components/ldata/translations/pt-PT.json
+++ b/custom_components/ldata/translations/pt-PT.json
@@ -25,13 +25,14 @@
             "init": {
                 "title": "Opções do Leviton LDATA",
                 "data": {
-                    "update_interval": "Intervalo de Atualização (segundos)",
-                    "three_phase": "Sistema Trifásico",
-                    "read_only": "Modo Apenas Leitura",
-                    "log_warnings": "Registar Avisos de Picos e Resets",
-                    "log_all_raw": "Registar Todos os Dados Brutos da API",
-                    "enable_specific_logging": "Ativar Registo de Campos Específicos",
-                    "log_fields": "Campos a Registar"
+                    "update_interval": "Intervalo de atualização (segundos)",
+                    "three_phase": "Sistema trifásico",
+                    "read_only": "Modo somente leitura",
+                    "log_warnings": "Registrar erros gerais do plugin",
+                    "log_data_warnings": "Registrar avisos de valor de dados (picos/reinicializações)",
+                    "log_all_raw": "Registrar todos os dados brutos da API",
+                    "enable_specific_logging": "Habilitar registro de campo específico",
+                    "log_fields": "Campos a serem registrados"
                 },
                 "data_description": {
                     "log_fields": "Para encontrar os nomes dos campos, ative 'Registar Todos os Dados Brutos da API' e verifique os registos do Home Assistant. Digite os dados acima separados por vírgula."

--- a/custom_components/ldata/translations/pt-PT.json
+++ b/custom_components/ldata/translations/pt-PT.json
@@ -4,17 +4,17 @@
             "already_configured": "Conta já configurada"
         },
         "error": {
-            "cannot_connect": "Falha na ligação",
-            "invalid_auth": "Falha na autenticação",
-            "unknown": "Erro desconhecido"
+            "cannot_connect": "Falha na conexão",
+            "invalid_auth": "Autenticação inválida",
+            "unknown": "Erro inesperado"
         },
         "step": {
             "user": {
                 "data": {
-                    "username": "my.leviton.com Utilizador",
-                    "password": "my.leviton.com Password",
-                    "three_phase": "3 Fases?",
-                    "read_only": "Somente leitura"
+                    "username": "Utilizador my.leviton.com",
+                    "password": "Palavra-passe my.leviton.com",
+                    "three_phase": "Sistema trifásico",
+                    "read_only": "Apenas leitura"
                 },
                 "title": "Configurar LDATA"
             }
@@ -23,12 +23,19 @@
     "options": {
         "step": {
             "init": {
+                "title": "Opções do Leviton LDATA",
                 "data": {
-                    "update_interval": "Intervalo de pesquisa my.leviton.com (segundos)",
-                    "three_phase": "3 Fases?",
-                    "read_only": "Somente leitura"
+                    "update_interval": "Intervalo de Atualização (segundos)",
+                    "three_phase": "Sistema Trifásico",
+                    "read_only": "Modo Apenas Leitura",
+                    "log_warnings": "Registar Avisos de Picos e Resets",
+                    "log_all_raw": "Registar Todos os Dados Brutos da API",
+                    "enable_specific_logging": "Ativar Registo de Campos Específicos",
+                    "log_fields": "Campos a Registar"
                 },
-                "description": "Configurar o controlador"
+                "data_description": {
+                    "log_fields": "Para encontrar os nomes dos campos, ative 'Registar Todos os Dados Brutos da API' e verifique os registos do Home Assistant. Insira aqui, separados por vírgulas."
+                }
             }
         }
     }


### PR DESCRIPTION
Took a week but I believe this is now ready (at least to be tested by someone other then myself).

Key changes:

- Changed logic to validate first new value to last value saved in DB after addon restart 
- Reworked Daily value logic to only allow increasing values. (any current bad value needs it's "state" corrected then HA reload or wait till the midnight reset)
- All data validation now allows for a Rounding Tolerance of 0.01 (decrease logging spam)
- Big rewrite to add more logging options and stream line code accommodating new logging options menu toggles for extra logging fuctions (Menu options are live refresh no HA reload needed).

The new options menu was to made it easier for logging debug info and I didn't want to simply add/remove it everybuild so I add realtime toggles to turn on/off the extra logging features. There is a toggle to turn off data validation warnings as well since Levitons API stream is currently trash and spams the logs.  