### PR TITLE
Updated switch logic and Multi LWHEM logic

### DIFF
--- a/custom_components/ldata/manifest.json
+++ b/custom_components/ldata/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/rwoldberg/ldata-ha/issues",
   "loggers": ["ldata"],
   "requirements": [],
-  "version": "1.1.20"
+  "version": "1.1.24"
 }


### PR DESCRIPTION
Allow breaker switch state to be held for 5 updates if value received is not a valid (issue #38) and Updated logic for multi LWHEM panel query so that if one panel fails query it does not halt the entire process. (relatable to issue #42 but not a fix).